### PR TITLE
add task to initial setup

### DIFF
--- a/lib/tasks/disable_modules.rake
+++ b/lib/tasks/disable_modules.rake
@@ -1,0 +1,18 @@
+namespace :disable_modules do
+
+  desc "Disable external login and register"
+  task external_login: :environment do
+    Setting['feature.twitter_login'] = false
+    Setting['feature.facebook_login'] = false
+    Setting['feature.google_login'] = false
+  end
+
+  desc "Disable modules"
+  task features: :environment do
+    Setting['feature.debates'] = true
+    Setting['feature.polls'] = false
+    Setting['feature.public_stats'] = false
+    Setting['feature.budgets'] = false
+    Setting['feature.legislation'] = false
+  end
+end


### PR DESCRIPTION
Where
=====
in rake task

What
====
config external login and modules visible

How to execute it in development
===

> rake disable_modules:features /or/  bundle exec rake disable_modules:features

after run

> rake disable_modules:external_login /or/ bundle exec rake disable_modules:external_login

How to execute it in production 
===

> RAILS_ENV=production rake disable_modules:features /or/ RAILS_ENV=production bundle exec rake disable_modules:features

after run

> RAILS_ENV=production rake disable_modules:external_login /or/ RAILS_ENV=production bundle exec rake disable_modules:external_login