### PR TITLE
Add summary and related pages count to site customization pages

### DIFF
--- a/app/controllers/admin/site_customization/pages_controller.rb
+++ b/app/controllers/admin/site_customization/pages_controller.rb
@@ -44,6 +44,8 @@ class Admin::SiteCustomization::PagesController < Admin::SiteCustomization::Base
         :add_in_menu,
         :status,
         :categories,
+        :summary,
+        :related_pages_count,
         :locale
       )
     end

--- a/app/models/site_customization/page.rb
+++ b/app/models/site_customization/page.rb
@@ -10,6 +10,8 @@ class SiteCustomization::Page < ActiveRecord::Base
   validates :title, presence: true
   validates :status, presence: true, inclusion: { in: VALID_STATUSES }
   validates :locale, presence: true
+  validates :summary, presence: true
+  validates :related_pages_count, presence: true, numericality: { greater_than: 0 }
 
   scope :published, -> { where(status: 'published').order('id DESC') }
   scope :with_more_info_flag, -> { where(status: 'published', more_info_flag: true).order('id ASC') }
@@ -26,6 +28,6 @@ class SiteCustomization::Page < ActiveRecord::Base
   end
 
   def strip_categories
-    self.categories = categories.split(',').map!(&:strip).join(',')
+    self.categories = categories.split(',').map!(&:strip).map!(&:downcase).join(',')
   end
 end

--- a/app/views/custom/admin/site_customization/pages/_form.html.erb
+++ b/app/views/custom/admin/site_customization/pages/_form.html.erb
@@ -56,6 +56,16 @@
       </div>
 
       <div class="margin-top">
+        <%= f.label :summary %>
+        <%= f.text_area :summary, label: false %>
+      </div>
+
+      <div class="margin-top">
+        <%= f.label :related_pages_count %>
+        <%= f.number_field :related_pages_count, min: 1, label: false %>
+      </div>
+
+      <div class="margin-top">
         <%= f.label :categories %>
         <%= f.text_field :categories, id: "site-categories-input", label: false, size: 80, maxlength: 80 %>
         <div class="small" id="used-categories-container">

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -185,6 +185,8 @@ es:
         slug: Slug
         status: Estado
         categories: Categorías
+        summary: Resumen
+        related_pages_count: Cantidad de páginas relacionadas
         title: Título
         updated_at: última actualización
         more_info_flag: Mostrar en la página de ayuda

--- a/db/migrate/20200415154651_add_columns_to_site_customization_pages.rb
+++ b/db/migrate/20200415154651_add_columns_to_site_customization_pages.rb
@@ -1,0 +1,6 @@
+class AddColumnsToSiteCustomizationPages < ActiveRecord::Migration
+  def change
+    add_column :site_customization_pages, :related_pages_count, :integer
+    add_column :site_customization_pages, :summary, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -990,18 +990,20 @@ ActiveRecord::Schema.define(version: 20200415160410) do
   add_index "site_customization_image_sites", ["name"], name: "index_site_customization_image_sites_on_name", unique: true, using: :btree
 
   create_table "site_customization_pages", force: :cascade do |t|
-    t.string   "slug",                                 null: false
-    t.string   "title",                                null: false
+    t.string   "slug",                                  null: false
+    t.string   "title",                                 null: false
     t.string   "subtitle"
     t.text     "content"
     t.boolean  "more_info_flag"
     t.boolean  "print_content_flag"
-    t.string   "status",             default: "draft"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.string   "status",              default: "draft"
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.string   "locale"
-    t.boolean  "add_in_menu",        default: false
+    t.boolean  "add_in_menu",         default: false
     t.string   "categories"
+    t.integer  "related_pages_count"
+    t.text     "summary"
   end
 
   create_table "spending_proposals", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,8 @@ ActiveRecord::Schema.define(version: 20200415160410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "unaccent"
+  enable_extension "pg_trgm"
 
   create_table "activities", force: :cascade do |t|
     t.integer  "user_id"


### PR DESCRIPTION
What
====
Add the ability to add summary and related pages count to site customization pages

How
===
Add the columns in the back end and fields in the form

Screenshots
===========
<img width="1059" alt="Captura de Pantalla 2020-04-15 a la(s) 15 40 33" src="https://user-images.githubusercontent.com/1376171/79375771-8af93600-7f2f-11ea-9346-e884780ebac9.png">
