### PR TITLE
Add image field to site customization pages

### DIFF
--- a/app/controllers/admin/site_customization/pages_controller.rb
+++ b/app/controllers/admin/site_customization/pages_controller.rb
@@ -44,7 +44,8 @@ class Admin::SiteCustomization::PagesController < Admin::SiteCustomization::Base
         :add_in_menu,
         :status,
         :categories,
-        :locale
+        :locale,
+        image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
       )
     end
 end

--- a/app/views/custom/admin/site_customization/pages/_form.html.erb
+++ b/app/views/custom/admin/site_customization/pages/_form.html.erb
@@ -63,6 +63,12 @@
         </div>
       </div>
 
+      <div class="image-form">
+        <div class="image small-12 column">
+          <%= render 'images/nested_image', imageable: @page, f: f %>
+        </div>
+      </div>
+
       <div class="small-12 medium-6 large-4 margin-top">
         <%= f.submit class: "button success expanded" %>
       </div>


### PR DESCRIPTION
What
====
Add images to site customization pages

How
===

- Include Imageable module in page model

- Add image field in form

- Add image params to permitted page params in pages controller

Screenshots
===========
<img width="853" alt="Captura de Pantalla 2020-04-15 a la(s) 16 14 37" src="https://user-images.githubusercontent.com/1376171/79378835-63589c80-7f34-11ea-9f43-3b7ab283de80.png">
<img width="685" alt="Captura de Pantalla 2020-04-15 a la(s) 16 15 24" src="https://user-images.githubusercontent.com/1376171/79378852-6a7faa80-7f34-11ea-9d4c-0b843202f585.png">
