### PR TITLE
Add view and route to list all articles

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -401,3 +401,15 @@ a.button-span-not-allowed-poll:hover {
 .article-container img {
   height: auto !important;
 }
+
+.article-title {
+  margin-top: 0 !important;
+}
+
+.article-item-container {
+  padding-top: 0 !important;
+}
+
+.article-image-container {
+  margin-bottom: 12px !important;
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,6 +25,6 @@ class PagesController < ApplicationController
   end
 
   def index
-    @pages = SiteCustomization::Page.unordered_published.order(updated_at: :desc).page(params[:page]).per(5)
+    @pages = SiteCustomization::Page.unordered_published.order(updated_at: :desc).page(params[:page]).per(20)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,4 +23,8 @@ class PagesController < ApplicationController
   rescue ActionView::MissingTemplate
     head 404
   end
+
+  def index
+    @pages = SiteCustomization::Page.unordered_published.order(updated_at: :desc).page(params[:page]).per(5)
+  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -4,6 +4,8 @@ class Image < ActiveRecord::Base
 
   TITLE_LEGHT_RANGE = 4..80
   MIN_SIZE = 475
+  ARTICLE_WIDTH = 340
+  ARTICLE_HEIGHT = 226
   MAX_IMAGE_SIZE = 1.megabyte
   ACCEPTED_CONTENT_TYPE = %w(image/jpeg image/jpg).freeze
 
@@ -68,11 +70,19 @@ class Image < ActiveRecord::Base
 
     def validate_image_dimensions
       if attachment_of_valid_content_type?
+        
         return true if imageable_class == Widget::Card
+        
+        if imageable_class == SiteCustomization::Page
+          dimensions = Paperclip::Geometry.from_file(attachment.queued_for_write[:original].path)
+          errors.add(:attachment, :exact_image_width, required_width: ARTICLE_WIDTH) if dimensions.width != ARTICLE_WIDTH
+          errors.add(:attachment, :exact_image_height, required_height: ARTICLE_HEIGHT) if dimensions.height != ARTICLE_HEIGHT
+        else
+          dimensions = Paperclip::Geometry.from_file(attachment.queued_for_write[:original].path)
+          errors.add(:attachment, :min_image_width, required_min_width: MIN_SIZE) if dimensions.width < MIN_SIZE
+          errors.add(:attachment, :min_image_height, required_min_height: MIN_SIZE) if dimensions.height < MIN_SIZE
+        end
 
-        dimensions = Paperclip::Geometry.from_file(attachment.queued_for_write[:original].path)
-        errors.add(:attachment, :min_image_width, required_min_width: MIN_SIZE) if dimensions.width < MIN_SIZE
-        errors.add(:attachment, :min_image_height, required_min_height: MIN_SIZE) if dimensions.height < MIN_SIZE
       end
     end
 

--- a/app/models/site_customization/page.rb
+++ b/app/models/site_customization/page.rb
@@ -14,7 +14,8 @@ class SiteCustomization::Page < ActiveRecord::Base
   validates :image, presence: true
   validates :related_pages_count, presence: true, numericality: { greater_or_equal_than: 0 }
 
-  scope :published, -> { where(status: 'published').order('id DESC') }
+  scope :unordered_published, -> { where(status: 'published') }
+  scope :published, -> { unordered_published.order('id DESC') }
   scope :with_more_info_flag, -> { where(status: 'published', more_info_flag: true).order('id ASC') }
   scope :with_same_locale, -> { where(locale: I18n.locale).order('id ASC') }
   scope :with_add_in_menu, -> { published.where(add_in_menu: true) }
@@ -30,7 +31,7 @@ class SiteCustomization::Page < ActiveRecord::Base
 
   def get_related_pages
     if !self.categories.blank? && self.related_pages_count > 0
-      pages = SiteCustomization::Page.where("id != #{self.id}").published
+      pages = SiteCustomization::Page.where("id != #{self.id}").unordered_published
       query = ''
       pages_categories = self.categories.split(',').uniq
       categories_limit = pages_categories.count - 1

--- a/app/views/custom/pages/_categories.html.erb
+++ b/app/views/custom/pages/_categories.html.erb
@@ -1,0 +1,10 @@
+<section class="tag-cloud-section margin-bottom categories-badges">
+  <h3 class="tag-cloud-title margin-top">CATEGORÍAS</h3>
+  <div class="tag-cloud margin-bottom">
+    <% format_categories(true).each do |cat| %>
+      <a href="#" class="tag-cloud-individual-tag category-tag">
+        <%= cat %>
+      </a>
+    <% end %>
+  </div>
+</section>

--- a/app/views/custom/pages/custom_page.html.erb
+++ b/app/views/custom/pages/custom_page.html.erb
@@ -21,16 +21,7 @@
   <% end %>
 
   <div class="small-12 medium-3 column margin-top">
-    <section class="tag-cloud-section margin-bottom categories-badges">
-      <h3 class="tag-cloud-title margin-top">CATEGORÍAS</h3>
-      <div class="tag-cloud margin-bottom">
-        <% format_categories(true).each do |cat| %>
-          <a href="#" class="tag-cloud-individual-tag category-tag">
-            <%= cat %>
-          </a>
-        <% end %>
-      </div>
-    </section>
+    <%= render "categories" %>
     <div>
       <% if @related_pages.any? %>
         <h3> MÁS NOTICIAS </h3>

--- a/app/views/custom/pages/index.html.erb
+++ b/app/views/custom/pages/index.html.erb
@@ -45,16 +45,7 @@
 
     <div class="small-12 medium-3 column">
       <aside class="sidebar">
-        <section class="tag-cloud-section margin-bottom categories-badges">
-          <h3 class="tag-cloud-title margin-top">CATEGORÍAS</h3>
-          <div class="tag-cloud margin-bottom">
-            <% format_categories(true).each do |cat| %>
-              <a href="#" class="tag-cloud-individual-tag category-tag">
-                <%= cat %>
-              </a>
-            <% end %>
-          </div>
-        </section>
+        <%= render "categories" %>
       </aside>
     </div>
   </div>

--- a/app/views/custom/pages/index.html.erb
+++ b/app/views/custom/pages/index.html.erb
@@ -1,0 +1,61 @@
+<div class="row-for-banners">
+  <div class="box">
+     <%= image_tag(image_path_for('banner-Idea.png'), class: 'float-center margin-bottom banner-img', width: '100%', alt: t("layouts.header.logo")) %>
+    <div class="column box-text">
+      <h2 class="banner-title inline-h-0">Noticias</h2>
+    </div>
+  </div>
+</div>
+
+<main>
+  <div class="row proposals-summary">
+    <div id="proposals" class="proposals-list small-12 medium-9 column">
+
+      <% @pages.each do |page| %>
+        <div >
+
+            <div class="proposal clear">
+              <div class="panel">
+                <div class="row">
+                  <div class="small-12 medium-3 column article-image-container">
+                    <%= image_tag page.image_url(:large), alt: page.title %>
+                  </div>
+                  <div class="small-12 medium-9 column article-item-container">
+                    <div class="proposal-content">
+                      <h3 class="article-title"><%= link_to page.title, page_path(page.slug) %></h3>
+
+                      <p class="proposal-info">
+                        <span><%= page.updated_at.strftime("%d/%m/%Y") %></span>
+                      </p>
+
+                      <div class="proposal-description">
+                        <p><%= page.summary %></p>
+                        <div class="truncate"></div>
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
+              </div>
+            </div>
+        </div>
+      <% end %>
+      <%= paginate @pages %>
+    </div>
+
+    <div class="small-12 medium-3 column">
+      <aside class="sidebar">
+        <section class="tag-cloud-section margin-bottom categories-badges">
+          <h3 class="tag-cloud-title margin-top">CATEGORÍAS</h3>
+          <div class="tag-cloud margin-bottom">
+            <% format_categories(true).each do |cat| %>
+              <a href="#" class="tag-cloud-individual-tag category-tag">
+                <%= cat %>
+              </a>
+            <% end %>
+          </div>
+        </section>
+      </aside>
+    </div>
+  </div>
+</main>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -261,6 +261,8 @@ en:
             attachment:
               min_image_width: "Image Width must be at least %{required_min_width}px"
               min_image_height: "Image Height must be at least %{required_min_height}px"
+              exact_image_height: "Image Height must be %{required_height}px exactly"
+              exact_image_width: "Image Width must be %{required_width}px exactly"
         newsletter:
           attributes:
             segment_recipient:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -260,6 +260,8 @@ es:
             attachment:
               min_image_width: "La imagen debe tener al menos %{required_min_width}px de largo"
               min_image_height: "La imagen debe tener al menos %{required_min_height}px de alto"
+              exact_image_height: "La imagen debe tener exactamente %{required_height}px de alto"
+              exact_image_width: "La imagen debe tener exactamente %{required_width}px de largo"
         newsletter:
           attributes:
             segment_recipient:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
   get '/condiciones-de-uso',                          to: 'pages#show', id: 'conditions',                     as: 'conditions'
   get '/politicas-de-privacidad',                     to: 'pages#show', id: 'privacy',                        as: 'privacy'
   get '/municipios',                                  to: 'pages#show', id: 'municipios',                     as: 'municipios'
+  get '/noticias',                                    to: 'pages#index',                                      as: 'all_articles'
 
   # Static pages
   get '/blog' => redirect("http://blog.consul/")


### PR DESCRIPTION
Reference
=====
https://trello.com/c/ADkGmjEe/101-genear-pagina-con-listado-de-noticias

What
====
Add a way to list all articles

How
===
- Add new route and action for pages controller

- Add image size restriction for pages images

- Create new published page scope to avoid ordering by id

Screenshots
===========
- Web view
<img width="1440" alt="Captura de Pantalla 2020-04-17 a la(s) 18 43 25" src="https://user-images.githubusercontent.com/1376171/79617201-46ab9880-80dd-11ea-945c-f4e80e2626d1.png">

- Mobile view(top)
<img width="383" alt="Captura de Pantalla 2020-04-17 a la(s) 18 43 45" src="https://user-images.githubusercontent.com/1376171/79617249-65119400-80dd-11ea-8b62-910cb7cc6d0d.png">

- Mobile view(bottom)
<img width="388" alt="Captura de Pantalla 2020-04-17 a la(s) 18 44 10" src="https://user-images.githubusercontent.com/1376171/79617279-79559100-80dd-11ea-9ee9-6151a4b7994a.png">
