### PR TITLE
Add new styling for homepage banner

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -477,13 +477,27 @@ a.button-span-not-allowed-poll:hover {
   width: 87%;
 }
 
-@media (max-width: 840px) and (min-width: 100px){
+.carusel-custom {
+  padding-bottom: 30px !important;
+}
+
+@media (max-width: 320px) and (min-width: 100px) {
+  .home-banner-text {
+    font-size: 16px !important;
+  }
+
+  .banner-box-text {
+    top: -39% !important;
+  }
+}
+
+@media (max-width: 375px) and (min-width: 100px) {
   .proposals-banner-title {
-    margin-top: 3% !important;
+    margin-top: 9% !important;
   }
 
   .home-banner-text {
-    font-size: 28px !important;
+    font-size: 18px !important;
   }
 }
 
@@ -493,7 +507,11 @@ a.button-span-not-allowed-poll:hover {
   }
 
   .home-banner-text {
-    font-size: 17px !important;
+    font-size: 21px !important;
+  }
+
+  .banner-box-text {
+    top: -37% !important;
   }
 
   .proposals-header {
@@ -501,12 +519,42 @@ a.button-span-not-allowed-poll:hover {
   }
 }
 
-@media (max-width: 374px) and (min-width: 100px) {
+@media (max-width: 840px) and (min-width: 100px){
   .proposals-banner-title {
-    margin-top: 9% !important;
+    margin-top: 3% !important;
   }
 
   .home-banner-text {
-    font-size: 14px !important;
+    font-size: 40px !important;
+  }
+
+  .banner-box-text {
+    top: -21% !important;
+  }
+}
+
+@media (max-width: 1023px) {
+  .proposals-home {
+    padding-top: 0 !important;
+  }
+}
+
+@media (max-width: 1024px) and (min-width: 841px) {
+  .banner-box-text {
+    top: 26% !important;
+  }
+
+  .home-banner-text {
+    font-size: 50px !important;
+  }
+}
+
+@media (min-width: 1440px) {
+  .banner-box-text {
+    top: 33% !important;
+  }
+
+  .home-banner-text {
+    font-size: 60px !important;
   }
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -456,12 +456,6 @@ a.button-span-not-allowed-poll:hover {
   top: 27px;
 }
 
-@media (max-width: 640px) {
-  .proposals-header {
-    top: 30px;
-  }
-}
-
 .proposals-icon {
   height: 50px;
   padding-right: 10px;
@@ -477,9 +471,19 @@ a.button-span-not-allowed-poll:hover {
   margin-left:0 !important;
 }
 
+.home-banner-text {
+  line-height: 1 !important;
+  text-align: left;
+  width: 87%;
+}
+
 @media (max-width: 840px) and (min-width: 100px){
   .proposals-banner-title {
     margin-top: 3% !important;
+  }
+
+  .home-banner-text {
+    font-size: 28px !important;
   }
 }
 
@@ -487,10 +491,22 @@ a.button-span-not-allowed-poll:hover {
   .proposals-banner-title {
     margin-top: 7% !important;
   }
+
+  .home-banner-text {
+    font-size: 17px !important;
+  }
+
+  .proposals-header {
+    top: 30px;
+  }
 }
 
-@media (max-width: 375px) and (min-width: 100px) {
+@media (max-width: 374px) and (min-width: 100px) {
   .proposals-banner-title {
     margin-top: 9% !important;
+  }
+
+  .home-banner-text {
+    font-size: 14px !important;
   }
 }

--- a/app/views/custom/welcome/index.html.erb
+++ b/app/views/custom/welcome/index.html.erb
@@ -25,9 +25,8 @@
           <%= image_tag header.image_url(:original), alt: t("layouts.header.logo"), class: 'float-center' %>
 
           <div class="column box-text">
-            <h2 class="banner-title inline-h-0"><%= header.title%></h2>
-            <div>
-              <%= link_to header.link_text, header.link_url, class: 'banner-font' %>
+            <div class="row">
+              <h2 class="banner-title small-12 medium-12 column home-banner-text inline-h-0"><%= header.title%></h2>
             </div>
           </div>
         </div>

--- a/app/views/custom/welcome/index.html.erb
+++ b/app/views/custom/welcome/index.html.erb
@@ -6,25 +6,26 @@
   <%= render "shared/canonical", href: root_url %>
 <% end %>
 <% if ((current_user.blank?) || (!current_user.blank? && session[current_user.id.to_s].blank?)) %>
-  <div id="myCarousel" class="carousel slide" data-ride="carousel">
+  <div id="myCarousel" class="carousel slide <%='carusel-custom' unless @headers.size > 1%>" data-ride="carousel">
     <!-- Indicators -->
-    <ol class="carousel-indicators">
-      <% @headers.each_with_index do |header, index| %>
-        <% if index == 0 %>
-          <li data-target="#myCarousel" data-slide-to="0" class="active"></li>
-        <% else %>
-          <li data-target="#myCarousel" data-slide-to="<%= index %>"></li>
+    <% if @headers.size > 1 %>
+      <ol class="carousel-indicators">
+        <% @headers.each_with_index do |header, index| %>
+          <% if index == 0 %>
+            <li data-target="#myCarousel" data-slide-to="0" class="active"></li>
+          <% else %>
+            <li data-target="#myCarousel" data-slide-to="<%= index %>"></li>
+          <% end %>
         <% end %>
-      <% end %>
-    </ol>
-
+      </ol>
+    <% end %>
     <!-- Wrapper for slides -->
     <div class="carousel-inner">
       <% @headers.each_with_index do |header, index| %>
         <div class="item <%= 'active' if index == 0 %>">
           <%= image_tag header.image_url(:original), alt: t("layouts.header.logo"), class: 'float-center' %>
 
-          <div class="column box-text">
+          <div class="column box-text banner-box-text">
             <div class="row">
               <h2 class="banner-title small-12 medium-12 column home-banner-text inline-h-0"><%= header.title%></h2>
             </div>
@@ -119,7 +120,7 @@
             </div>
           </div>
           <% @recommendations.in_groups_of(3).each do |recommendations| %>
-            <div class="row">
+            <div>
               <% recommendations.compact.each do |recommendation|%>
                 <%= link_to recommendation.link_url, target: :blank do %>
                   <div class="large-4 medium-4 column float-left">
@@ -142,7 +143,7 @@
               <h1 class="h1-wellcome">Destacados</h1>
             </div>
           </div>
-          <div class="row">
+          <div>
             <% @recommendations.limit(3).each do |recommendation| %>
               <%= link_to recommendation.link_url, target: :blank do %>
                 <div class="medium-4 column float-left">


### PR DESCRIPTION
Reference
=====
https://trello.com/c/TPYgI1uF/105-ajustar-banner-del-home

What
====
- Change the image and style of home page banner

How
===
- Change the image from admin configuration and update styles of welcome index view

Screenshots
===========
- Desktop app
<img width="1440" alt="Captura de Pantalla 2020-04-23 a la(s) 18 05 34" src="https://user-images.githubusercontent.com/1376171/80151543-9d5b1b80-8590-11ea-839e-8cdd228deb5c.png">

- Mobile view 1(tablet)
<img width="1053" alt="Captura de Pantalla 2020-04-23 a la(s) 18 07 23" src="https://user-images.githubusercontent.com/1376171/80151616-bd8ada80-8590-11ea-8a36-b41c8481efca.png">

- Mobile view 2
<img width="362" alt="Captura de Pantalla 2020-04-23 a la(s) 18 07 37" src="https://user-images.githubusercontent.com/1376171/80151715-e0b58a00-8590-11ea-91fd-8af0910d8a5d.png">