### PR TITLE
Update style for featured articles cards

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -535,6 +535,15 @@ header .subnavigation {
   text-align: left;
 }
 
+.home-recomendations {
+  border-bottom: solid 24px #f9bd41;
+}
+
+.home-text-feature {
+  text-align: left; 
+  color: white;
+}
+
 @media (max-width: 320px) and (min-width: 100px) {
   .home-banner-text {
     font-size: 16px !important;

--- a/app/views/custom/welcome/index.html.erb
+++ b/app/views/custom/welcome/index.html.erb
@@ -150,8 +150,12 @@
                 <%= link_to recommendation.link_url, target: :blank do %>
                   <div class="large-4 medium-4 column float-left">
                     <p class="margin-img-2">
-                      <%= image_tag recommendation.image_url(:original), alt: t("layouts.header.logo"), class: 'float-center' %>
-                      <p class="text-feature-img"><%= recommendation.link_text%></p>
+                      <div class="image-text-container home-recomendations">
+                        <%= image_tag recommendation.image_url(:original), alt: t("layouts.header.logo"), class: 'float-center' %>
+                        <div class="image-text"> 
+                          <p class="text-feature-img home-text-feature"><%= recommendation.link_text %></p>
+                        </div>
+                      </div>
                     </p>
                   </div>
                 <% end %>
@@ -173,8 +177,12 @@
               <%= link_to recommendation.link_url, target: :blank do %>
                 <div class="medium-4 column float-left">
                   <p class="margin-img-2">
-                    <%= image_tag recommendation.image_url(:original), alt: t("layouts.header.logo"), class: 'float-center' %>
-                    <p class="text-feature-img"><%= recommendation.link_text%></p>
+                   <div class="image-text-container home-recomendations">
+                      <%= image_tag recommendation.image_url(:original), alt: t("layouts.header.logo"), class: 'float-center' %>
+                      <div class="image-text"> 
+                        <p class="text-feature-img home-text-feature"><%= recommendation.link_text %></p>
+                      </div>
+                    </div>
                   </p>
                 </div>
               <% end %>


### PR DESCRIPTION
Reference
=====
https://trello.com/c/u4bcnRwE/109-ajustar-novedades-en-la-home-segun-se-ve-la-imagen-de-la-parte-de-destacados

What
====
- Change the style for featured articles cards

How
===
- Add new classes and css styles for the home featured articles cards

Screenshots
===========
- Web view
<img width="1440" alt="Captura de Pantalla 2020-04-30 a la(s) 11 32 55" src="https://user-images.githubusercontent.com/1376171/80726020-41d1e600-8ada-11ea-9899-bfe3e34c9e73.png">

- Mobile view
<img width="433" alt="Captura de Pantalla 2020-04-30 a la(s) 11 33 15" src="https://user-images.githubusercontent.com/1376171/80726093-58783d00-8ada-11ea-827d-ffbd17a4c2a3.png">
