### PR TITLE
Divide home banner text in two to have more structure control

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -546,11 +546,15 @@ header .subnavigation {
 
 @media (max-width: 320px) and (min-width: 100px) {
   .home-banner-text {
-    font-size: 16px !important;
+    font-size: 14px !important;
   }
 
   .banner-box-text {
-    top: -39% !important;
+    top: -9% !important;
+  }
+
+  .subtitle-home-text {
+    margin-top: -8px !important;
   }
 
   .general-banner-title {
@@ -579,11 +583,15 @@ header .subnavigation {
   }
 
   .banner-box-text {
-    top: -37% !important;
+    top: -16% !important;
   }
 
   .home-banner-text {
-    font-size: 18px !important;
+    font-size: 16px !important;
+  }
+
+  .subtitle-home-text {
+    margin-top: -7px !important;
   }
 
   .search-column {
@@ -632,11 +640,15 @@ header .subnavigation {
   }
 
   .home-banner-text {
-    font-size: 21px !important;
+    font-size: 18px !important;
   }
 
   .banner-box-text {
-    top: -37% !important;
+    top: -10% !important;
+  }
+
+  .subtitle-home-text {
+    margin-top: -7px !important;
   }
 
   .proposals-header {
@@ -668,12 +680,17 @@ header .subnavigation {
   }
 
   .home-banner-text {
-    font-size: 40px !important;
+    font-size: 36px !important;
   }
 
   .banner-box-text {
-    top: -21% !important;
+    top: 6% !important;
   }
+
+  .subtitle-home-text {
+    margin-top: -8px !important;
+  }
+
   .small-subnavigation-items {
     width: 103%;
   }
@@ -758,10 +775,17 @@ header .subnavigation {
   }
 }
 
-@media (min-width: 1025px) { 
+@media (max-width: 1439px) and (min-width: 1025px) { 
   .home-banner-text {
-    font-size: 50px !important;
+    font-size: 55px !important;
     margin-top: -3% !important;
+  }
+
+  .subtitle-home-text {
+    margin-top: -13px !important;
+  }
+  .banner-box-text {
+    margin-top: 11px !important;
   }
 
   .general-banner-title,

--- a/app/controllers/admin/widget/cards_controller.rb
+++ b/app/controllers/admin/widget/cards_controller.rb
@@ -39,7 +39,7 @@ class Admin::Widget::CardsController < Admin::BaseController
   private
 
   def card_params
-    params.require(:widget_card).permit(:label, :title, :description, :link_text, :link_url,
+    params.require(:widget_card).permit(:label, :title, :subtitle, :description, :link_text, :link_url,
                                         :button_text, :button_url, :alignment, :header,
                                         :init_datetime, :end_datetime, :order_number,
                                         image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy])

--- a/app/views/custom/admin/widget/cards/_form.html.erb
+++ b/app/views/custom/admin/widget/cards/_form.html.erb
@@ -12,6 +12,11 @@
   </div>
   <div class="row">
     <div class="small-12 medium-12 column">
+      <%= f.text_field :subtitle %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="small-12 medium-12 column">
       <%= f.text_area :description, rows: 5 %>
     </div>
   </div>

--- a/app/views/custom/welcome/index.html.erb
+++ b/app/views/custom/welcome/index.html.erb
@@ -28,6 +28,7 @@
           <div class="column box-text banner-box-text">
             <div class="row">
               <h2 class="banner-title small-12 medium-12 column home-banner-text inline-h-0"><%= header.title%></h2>
+              <h2 class="banner-title small-12 subtitle-home-text medium-12 column home-banner-text inline-h-0"><%= header.subtitle%></h2>
             </div>
           </div>
         </div>

--- a/db/migrate/20200430181146_add_subtitle_to_widget_cards.rb
+++ b/db/migrate/20200430181146_add_subtitle_to_widget_cards.rb
@@ -1,0 +1,5 @@
+class AddSubtitleToWidgetCards < ActiveRecord::Migration
+  def change
+    add_column :widget_cards, :subtitle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200415160410) do
+ActiveRecord::Schema.define(version: 20200430181146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -991,6 +991,18 @@ ActiveRecord::Schema.define(version: 20200415160410) do
 
   add_index "site_customization_image_sites", ["name"], name: "index_site_customization_image_sites_on_name", unique: true, using: :btree
 
+  create_table "site_customization_images", force: :cascade do |t|
+    t.string   "name",               null: false
+    t.string   "image_file_name"
+    t.string   "image_content_type"
+    t.integer  "image_file_size"
+    t.datetime "image_updated_at"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+  end
+
+  add_index "site_customization_images", ["name"], name: "index_site_customization_images_on_name", unique: true, using: :btree
+
   create_table "site_customization_pages", force: :cascade do |t|
     t.string   "slug",                                  null: false
     t.string   "title",                                 null: false
@@ -1254,6 +1266,7 @@ ActiveRecord::Schema.define(version: 20200415160410) do
     t.datetime "init_datetime"
     t.datetime "end_datetime"
     t.integer  "order_number"
+    t.string   "subtitle"
   end
 
   create_table "widget_feeds", force: :cascade do |t|
@@ -1265,11 +1278,13 @@ ActiveRecord::Schema.define(version: 20200415160410) do
 
   add_foreign_key "administrators", "users"
   add_foreign_key "annotations", "legacy_legislations"
+  add_foreign_key "annotations", "legacy_legislations"
   add_foreign_key "annotations", "users"
   add_foreign_key "budget_investments", "communities"
   add_foreign_key "documents", "users"
   add_foreign_key "failed_census_calls", "poll_officers"
   add_foreign_key "failed_census_calls", "users"
+  add_foreign_key "flags", "users"
   add_foreign_key "flags", "users"
   add_foreign_key "follows", "users"
   add_foreign_key "geozones_polls", "geozones"
@@ -1293,6 +1308,7 @@ ActiveRecord::Schema.define(version: 20200415160410) do
   add_foreign_key "poll_partial_results", "poll_questions", column: "question_id"
   add_foreign_key "poll_partial_results", "users", column: "author_id"
   add_foreign_key "poll_question_answer_videos", "poll_question_answers", column: "answer_id"
+  add_foreign_key "poll_question_answers", "poll_questions", column: "question_id"
   add_foreign_key "poll_question_answers", "poll_questions", column: "question_id"
   add_foreign_key "poll_questions", "polls"
   add_foreign_key "poll_questions", "proposals"


### PR DESCRIPTION
Reference
https://trello.com/c/RKqmo6Dm/110-agregar-subtitlo-al-banner-del-home

What
====
- Divide the home banner text in two to have better control

How
===
- Add subtitle attribute to widget card

- Whitelist the param and add it to the widget card form

- Apply new styles

- In administration set home banner second half text as subtitle

Screenshots
===========
- Web view
<img width="1440" alt="Captura de Pantalla 2020-04-30 a la(s) 18 20 31" src="https://user-images.githubusercontent.com/1376171/80761018-2c77ae80-8b10-11ea-981e-bc8a54b7dd34.png">

- Mobile view(1/2)
<img width="772" alt="Captura de Pantalla 2020-04-30 a la(s) 18 20 14" src="https://user-images.githubusercontent.com/1376171/80761116-57fa9900-8b10-11ea-97f4-5869effab4a8.png">

- Mobile view(2/2)
<img width="323" alt="Captura de Pantalla 2020-04-30 a la(s) 18 19 39" src="https://user-images.githubusercontent.com/1376171/80761178-752f6780-8b10-11ea-8a2b-fb2055d88cd7.png">

