### PR TITLE
Change the how the articles category filter shows the results

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -27,7 +27,7 @@ class PagesController < ApplicationController
   def index
     @search_terms = params[:search]
     if @search_terms
-      @pages = SiteCustomization::Page.for_title_or_summary(@search_terms).page(params[:page]).per(20)
+      @pages = SiteCustomization::Page.for_title_summary_or_category(@search_terms).page(params[:page]).per(20)
     else
       @category = params[:category]
       if @category

--- a/app/models/site_customization/page.rb
+++ b/app/models/site_customization/page.rb
@@ -20,7 +20,7 @@ class SiteCustomization::Page < ActiveRecord::Base
   scope :with_same_locale, -> { where(locale: I18n.locale).order('id ASC') }
   scope :with_add_in_menu, -> { published.where(add_in_menu: true) }
   scope :for_category, ->(category) { unordered_published.where("categories ILIKE :category", category: "%#{category}%").order(updated_at: :desc) }
-  scope :for_title_or_summary, ->(search) { unordered_published.where("title ILIKE :search OR summary ILIKE :search", search: "%#{search}%").order(updated_at: :desc) }
+  scope :for_title_summary_or_category, ->(search) { unordered_published.where("title ILIKE :search OR summary ILIKE :search OR categories ILIKE :search", search: "%#{search}%").order(updated_at: :desc) }
 
   def url
     "/#{slug}"

--- a/app/views/custom/pages/index.html.erb
+++ b/app/views/custom/pages/index.html.erb
@@ -10,7 +10,7 @@
     <%= image_tag(image_path_for('banner-general.png'), class: 'banner-image float-center margin-bottom banner-img', width: '100%', alt: t("layouts.header.logo")) %>
     <div class="box-text general-box-text">
       <div class="row">
-        <h2 class="banner-title general-banner-title column small-12 inline-h-0"><%= format_articles_header(@category) %></h2>
+        <h2 class="banner-title general-banner-title column small-12 inline-h-0">Noticias</h2>
       </div>
     </div>
   </div>
@@ -23,14 +23,15 @@
     </div>
   </div>
 <main>
-  <% if @search_terms  %>
+  <% if @search_terms || @category  %>
+    <% query_term = @search_terms || @category %>
     <div class="highlight no-margin-top no-margin-top-small margin-bottom">
       <div class="row">
         <div class="small-12 column">
           <h2><%= t("shared.search_results") %></h2>
           <p>
             <%= page_entries_info @pages %>
-            <%= t("pages.index.search_results_html", count: @pages.size, search_term: @search_terms) %>
+            <%= t("pages.index.search_results_html", count: @pages.size, search_term: query_term) %>
           <p>
         </div>
       </div>


### PR DESCRIPTION
Reference
=====
https://trello.com/c/46xRyESu/111-mostrar-el-resultado-de-filtro-de-categorias-de-noticias-de-la-misma-manera-que-el-resultado-del-buscador

What
====
- Show the results of the category filter for articles the same way the results of search bar are shown

How
===
- Add logic in custom pages index view

Screenshots
===========
<img width="1440" alt="Captura de Pantalla 2020-04-30 a la(s) 18 33 08" src="https://user-images.githubusercontent.com/1376171/80762293-a1e47e80-8b12-11ea-8c20-97af0440f5d1.png">
