### PR TITLE
Update logic for showing proposal status message

### DIFF
--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -67,4 +67,14 @@ module ProposalsHelper
     proposal.featured ? "No Destacar" : "Destacar"
   end
 
+  def format_archived_text(proposal)
+    if proposal.text_show_finished.blank? && proposal.text_show_archived.blank?
+      "Esta idea ha sido archivada y ya no puede recoger apoyos."
+    elsif proposal.text_show_finished.blank?
+      proposal.text_show_archived
+    else
+      proposal.text_show_finished
+    end
+  end
+
 end

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -77,4 +77,20 @@ module ProposalsHelper
     end
   end
 
+  def document_link(proposal, show, text)
+    if proposal.link_success
+      link_to proposal.link_success,
+            class: "button button-support expanded #{ show ? 'view-document-show' : 'view-document-list'}",
+            title: "Ver documento", target: '_blank' do 
+                text
+      end
+    elsif proposal.link_not_success
+      link_to proposal.link_not_success,
+          class: "button button-support expanded #{ show ? 'view-document-show' : 'view-document-list'}",
+          title: "Ver documento", target: '_blank' do
+        text
+      end 
+    end
+  end
+
 end

--- a/app/views/custom/management/proposals/_proposal.html.erb
+++ b/app/views/custom/management/proposals/_proposal.html.erb
@@ -65,34 +65,7 @@
       <div id="<%= dom_id(proposal) %>_votes"
            class="small-12 medium-3 column supports-container"
            <%= 'data-equalizer-watch' if feature?(:allow_images) && proposal.image.present? %>>
-        <% if proposal.not_successful? %>
-          <div class="padding text-center">
-            <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>
-            <p>Esta propuesta no ha sido viable</p>
-          </div>
-        <% elsif proposal.successful? %>
-          <div class="padding text-center">
-            <p>
-              <%= t("proposals.proposal.successful",
-                  voting: link_to(t("proposals.proposal.voting"), polls_path)).html_safe %>
-            </p>
-          </div>
-          <% if can? :create, Poll::Question %>
-            <p class="text-center">
-              <%= link_to t('poll_questions.create_question'),
-                          new_admin_question_path(proposal_id: proposal.id),
-                          class: "button hollow" %>
-            </p>
-          <% end %>
-        <% elsif proposal.archived? %>
-          <div class="padding text-center">
-            <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>
-            <p><%= t("proposals.proposal.archived") %></p>
-          </div>
-        <% else %>
-          <%= render 'votes',
-                    { proposal: proposal, vote_url: vote_proposal_path(proposal, value: 'yes') } %>
-        <% end %>
+        <%= render 'proposals/message_options', proposal: proposal, show: false %>
       </div>
     </div>
     <%= render 'set_state', proposal: proposal%>

--- a/app/views/custom/proposals/_message_options.html.erb
+++ b/app/views/custom/proposals/_message_options.html.erb
@@ -68,12 +68,6 @@
     <p>
       <%= format_archived_text(proposal) %>
     </p>
-    <% unless proposal.link_success.blank? %>
-      <%= link_to proposal.link_success,
-            class: "button button-support expanded #{ show ? 'view-document-show' : 'view-document-list'}",
-            title: "Ver documento", target: '_blank' do %>
-          Ver documento
-      <% end %>
-    <% end %>
+    <%= document_link(proposal, show, "Ver Documento") %>
   </div>
 <% end %>

--- a/app/views/custom/proposals/_message_options.html.erb
+++ b/app/views/custom/proposals/_message_options.html.erb
@@ -1,7 +1,4 @@
-<% if !proposal.can_vote? %>
-  <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>
-  <p>El período para apoyar esta idea ha finalizado.</p>
-<% elsif proposal.not_successful? %>
+<% if proposal.not_successful? %>
   <div class="padding text-center">
     <% if proposal.text_show_finished.blank? %>
       <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>
@@ -50,13 +47,33 @@
                   class: "button hollow" %>
     </p>
   <% end %>
+<% elsif proposal.open?%>
+  <% if proposal.archived? || !proposal.can_vote? %>
+    <div class="padding text-center">
+      <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>
+      <% if proposal.archived? %>
+        <p>Esta idea ha sido archivada y ya no puede recoger apoyos.</p>
+      <% else %>
+        <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>
+        <p>El período para apoyar esta idea ha finalizado.</p>
+      <% end %>
+    </div>
+  <% else %>
+    <%= render 'votes',
+            { proposal: proposal, vote_url: vote_proposal_path(proposal, value: 'yes') } %>
+  <% end %>
 <% elsif proposal.archived? %>
   <div class="padding text-center">
     <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>
-    <p><%= t("proposals.proposal.archived") %></p>
+    <p>
+      <%= format_archived_text(proposal) %>
+    </p>
+    <% unless proposal.link_success.blank? %>
+      <%= link_to proposal.link_success,
+            class: "button button-support expanded #{ show ? 'view-document-show' : 'view-document-list'}",
+            title: "Ver documento", target: '_blank' do %>
+          Ver documento
+      <% end %>
+    <% end %>
   </div>
-<% else %>
-  <%= render 'votes',
-            { proposal: proposal, vote_url: vote_proposal_path(proposal, value: 'yes') } %>
 <% end %>
-


### PR DESCRIPTION
Reference
=====
https://trello.com/c/ooB1T5a9/128-mostrar-mensajes-correctamente-en-ideas

What
====
- Update the logic for showing proposal status messages

How
===
- Add new conditions in message options partial

- Use that partial in management proposals view to have same messages as users proposals

Screenshots
===

- Unsuccessful with document link

<img width="883" alt="Captura de Pantalla 2020-06-02 a la(s) 11 21 02" src="https://user-images.githubusercontent.com/1376171/83531431-5b908f80-a4c3-11ea-8055-d9a4efbb970a.png">

- Archived with custom text
<img width="890" alt="Captura de Pantalla 2020-06-02 a la(s) 11 21 23" src="https://user-images.githubusercontent.com/1376171/83531519-79f68b00-a4c3-11ea-84fa-2efd3f840d97.png">

- Successful
<img width="883" alt="Captura de Pantalla 2020-06-02 a la(s) 11 21 31" src="https://user-images.githubusercontent.com/1376171/83531586-90044b80-a4c3-11ea-8619-243512f70fae.png">

- Archived with no custom text
<img width="884" alt="Captura de Pantalla 2020-06-02 a la(s) 11 21 38" src="https://user-images.githubusercontent.com/1376171/83531649-a3afb200-a4c3-11ea-893a-d69eb9d36427.png">

- Open and can vote
<img width="1043" alt="Captura de Pantalla 2020-06-02 a la(s) 11 25 49" src="https://user-images.githubusercontent.com/1376171/83531852-df4a7c00-a4c3-11ea-850f-82f9ecc31be3.png">
