### PR TITLE
Add archived_at column to proposals

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -561,16 +561,17 @@ header .subnavigation {
 }
 
 .archived-info {
-  font-size: 1.5rem;
+  font-size: 1.0625rem !important;
   color: black;
   margin: 0;
+  font-weight: bold;
 }
 
 .archived-info-index {
-  font-size: 18px;
   color: black;
   margin: 0;
   margin-top: 15px;
+  font-weight: bold;
 }
 
 @media (max-width: 320px) and (min-width: 100px) {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -560,6 +560,19 @@ header .subnavigation {
   overflow-x: auto;
 }
 
+.archived-info {
+  font-size: 1.5rem;
+  color: black;
+  margin: 0;
+}
+
+.archived-info-index {
+  font-size: 18px;
+  color: black;
+  margin: 0;
+  margin-top: 15px;
+}
+
 @media (max-width: 320px) and (min-width: 100px) {
   .home-banner-text {
     font-size: 14px !important;

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -93,4 +93,12 @@ module ProposalsHelper
     end
   end
 
+  def format_archived_at_text(proposal, class_name)
+    if proposal.archived?
+      text = t('proposals.archived')
+      text += " - #{proposal.archived_at.strftime('%d/%m/%Y')}" if proposal.archived_at
+      content_tag(:h2, text, class: class_name)
+    end
+  end
+
 end

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -97,7 +97,7 @@ module ProposalsHelper
     if proposal.archived?
       text = t('proposals.archived')
       text += " - #{proposal.archived_at.strftime('%d/%m/%Y')}" if proposal.archived_at
-      content_tag(:h2, text, class: class_name)
+      content_tag(:p, text, class: class_name)
     end
   end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -136,7 +136,7 @@ class Proposal < ActiveRecord::Base
 
   def self.bulk_archive(ids, archived_text)
     Proposal.where(id: ids).update_all(state: Proposal::STATES[:archived],
-      text_show_archived: archived_text)
+      text_show_archived: archived_text, archived_at: Date.today)
   end
 
   def total_votes
@@ -276,7 +276,7 @@ class Proposal < ActiveRecord::Base
   end
 
   def archived!
-    update(state: STATES[:archived])
+    update(state: STATES[:archived], archived_at: Date.today)
   end
 
   def state_text

--- a/app/views/custom/proposals/_proposal.html.erb
+++ b/app/views/custom/proposals/_proposal.html.erb
@@ -22,11 +22,14 @@
           <% cache [locale_and_user_status(proposal), 'index', proposal, proposal.author] do %>
             <h3><%= link_to proposal.title, namespaced_proposal_path(proposal) %></h3>
             <p class="proposal-info">
+              <%= format_archived_at_text(proposal, "archived-info-index") %>
               <span class="icon-comments"></span>&nbsp;
               <%= link_to t("proposals.proposal.comments", count: proposal.comments_count), namespaced_proposal_path(proposal, anchor: "comments") %>
 
-              <span class="bullet">&nbsp;&bull;&nbsp;</span>
-              <%= l proposal.created_at.to_date %>
+              <% unless proposal.archived_at %>
+                <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                <%= l proposal.created_at.to_date %>
+              <% end %>
 
               <% if proposal.author.hidden? || proposal.author.erased? %>
                 <span class="bullet">&nbsp;&bull;&nbsp;</span>

--- a/app/views/custom/proposals/show.html.erb
+++ b/app/views/custom/proposals/show.html.erb
@@ -29,11 +29,14 @@
         <% end %>
 
         <div class="proposal-info">
+          <%= format_archived_at_text(@proposal, "archived-info") %>
           <span class="icon-comments"></span>&nbsp;
           <%= link_to t("proposals.show.comments", count: @proposal.comments_count), "#comments" %>
           <span class="bullet">&nbsp;&bull;&nbsp;</span>
-          <%= l @proposal.created_at.to_date %>
-          <span class="bullet">&nbsp;&bull;&nbsp;</span>
+          <% unless @proposal.archived_at %>
+            <%= l @proposal.created_at.to_date %>
+            <span class="bullet">&nbsp;&bull;&nbsp;</span>
+          <% end %>
           <%= render '/shared/author_info', resource: @proposal %>
 
           <% if current_user %>

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -160,6 +160,7 @@ es:
       success: 'Aprobada'
       not_success: 'No Aprobada'
       archived: 'Archivada'
+    archived: 'Idea Archivada'
     banner-text: "Montevideo necesita tu aporte para crecer. Por eso te invitamos a que te sumes a los debates sobre los temas que más te preocupan, propongas ideas para mejorar la calidad de vida de todos y todas, y decidamos en conjunto cuáles se llevan a cabo."
     create:
       form:

--- a/db/migrate/20200612124542_add_archived_at_to_proposal.rb
+++ b/db/migrate/20200612124542_add_archived_at_to_proposal.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToProposal < ActiveRecord::Migration
+  def change
+    add_column :proposals, :archived_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200529181012) do
+ActiveRecord::Schema.define(version: 20200612124542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -902,6 +902,7 @@ ActiveRecord::Schema.define(version: 20200529181012) do
     t.string   "link_success"
     t.boolean  "featured",                       default: false
     t.string   "text_show_archived"
+    t.date     "archived_at"
   end
 
   add_index "proposals", ["author_id", "hidden_at"], name: "index_proposals_on_author_id_and_hidden_at", using: :btree


### PR DESCRIPTION
Reference
=====
* https://trello.com/c/gb2rjffb/129-agregar-fecha-de-idea-archivda

What
====
- Add archived at column to proposal model

How
===
- Create migration

- Add logic to display correct text if proposal is archived

Screenshots
===========
- Archived proposal show without archived_at
<img width="918" alt="Captura de Pantalla 2020-06-15 a la(s) 11 18 53" src="https://user-images.githubusercontent.com/1376171/84668853-7bc84180-aefa-11ea-987b-295c8a4d4716.png">


- Archived proposal show with archived_at
<img width="578" alt="Captura de Pantalla 2020-06-15 a la(s) 11 18 29" src="https://user-images.githubusercontent.com/1376171/84668890-88e53080-aefa-11ea-894e-19f7f99c9ab0.png">


- Proposal index
<img width="898" alt="Captura de Pantalla 2020-06-15 a la(s) 11 18 12" src="https://user-images.githubusercontent.com/1376171/84669079-d06bbc80-aefa-11ea-8961-3634126d19e5.png">


